### PR TITLE
refactor: remove whitespace from Ruby file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # midori-todo-example
+
 TODO List example built with midori and Vue.js
 
 Requirements:
+
 - Ruby >= 2.2.6
 - Node >= 6.0
 - Yarn >= 0.22

--- a/routes/error_route.rb
+++ b/routes/error_route.rb
@@ -1,4 +1,4 @@
-define_error :unauthorized_error, 
+define_error :unauthorized_error,
              :user_conflict_error
 
 class ErrorRoute < Midori::API


### PR DESCRIPTION
Add blank lines around the heading and list in the README